### PR TITLE
Bump actions/checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: ${{ matrix.ruby }} rails-${{ matrix.gemfile }}  couchbase-${{ matrix.couchbase }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo apt-get update && sudo apt-get install libevent-dev libev-dev python-httplib2
     - uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
To get rid of the following warning:

`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout`

As `actions/checkout` uses Node.js 16 since `v3` release.