### PR TITLE
Fix Couchbase version

### DIFF
--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
     gem.add_runtime_dependency     'activemodel',   ENV["ACTIVE_MODEL_VERSION"] || '>= 5.2'
     gem.add_runtime_dependency     'activerecord',  ENV["ACTIVE_MODEL_VERSION"] || '>= 5.2'
 
-    gem.add_runtime_dependency     'couchbase'
+    gem.add_runtime_dependency     'couchbase'.    '~> 3.3.0'
     gem.add_runtime_dependency     'radix',        '~> 2.2' # converting numbers to and from any base
 
     gem.add_development_dependency 'rake',         '~> 12.2'

--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
     gem.add_runtime_dependency     'activemodel',   ENV["ACTIVE_MODEL_VERSION"] || '>= 5.2'
     gem.add_runtime_dependency     'activerecord',  ENV["ACTIVE_MODEL_VERSION"] || '>= 5.2'
 
-    gem.add_runtime_dependency     'couchbase'.    '~> 3.3.0'
+    gem.add_runtime_dependency     'couchbase',    '~> 3.3.0'
     gem.add_runtime_dependency     'radix',        '~> 2.2' # converting numbers to and from any base
 
     gem.add_development_dependency 'rake',         '~> 12.2'


### PR DESCRIPTION
We are not compatible yet with new release of Couchbase ruby client.
https://github.com/couchbase/couchbase-ruby-client/releases/tag/3.4.0