### PR TITLE
Prevent to expose dead callbacks for nested

### DIFF
--- a/lib/couchbase-orm/base.rb
+++ b/lib/couchbase-orm/base.rb
@@ -123,7 +123,6 @@ module CouchbaseOrm
         extend Enum
 
         define_model_callbacks :initialize, :only => :after
-        define_model_callbacks :create, :destroy, :save, :update
 
         Metadata = Struct.new(:cas)
 
@@ -211,6 +210,8 @@ module CouchbaseOrm
         extend HasMany
         extend Index
         extend IgnoredProperties
+
+        define_model_callbacks :create, :destroy, :save, :update
 
         class << self
             def connect(**options)

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -220,6 +220,15 @@ describe CouchbaseOrm::Base do
         it_behaves_like "ActiveModel"
     end
 
+    it 'does not expose callbacks for nested that wont never be called' do
+        expect{
+            class InvalidNested < CouchbaseOrm::NestedDocument
+                before_save {p "this should raise on loading class"}
+            end
+
+        }.to raise_error NoMethodError
+    end
+
     describe '.ignored_properties' do
 
 


### PR DESCRIPTION
Nested documents do not have save method, then all commit related callbacks would never be called for them.
Let's remove them.

https://app.asana.com/0/1203552334223822/1204101687052473/f