### PR TITLE
Upgrade Couchbase ruby client version to 3.4.2

### DIFF
--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
     gem.add_runtime_dependency     'activemodel',   ENV["ACTIVE_MODEL_VERSION"] || '>= 5.2'
     gem.add_runtime_dependency     'activerecord',  ENV["ACTIVE_MODEL_VERSION"] || '>= 5.2'
 
-    gem.add_runtime_dependency     'couchbase',    '~> 3.3.0'
+    gem.add_runtime_dependency     'couchbase',    '~> 3.4.1'
     gem.add_runtime_dependency     'radix',        '~> 2.2' # converting numbers to and from any base
 
     gem.add_development_dependency 'rake',         '~> 12.2'

--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
     gem.add_runtime_dependency     'activemodel',   ENV["ACTIVE_MODEL_VERSION"] || '>= 5.2'
     gem.add_runtime_dependency     'activerecord',  ENV["ACTIVE_MODEL_VERSION"] || '>= 5.2'
 
-    gem.add_runtime_dependency     'couchbase',    '~> 3.4.1'
+    gem.add_runtime_dependency     'couchbase',    '~> 3.4.2'
     gem.add_runtime_dependency     'radix',        '~> 2.2' # converting numbers to and from any base
 
     gem.add_development_dependency 'rake',         '~> 12.2'


### PR DESCRIPTION
This should fix crashing MacOs Ruby on trying to connect on unreachable server.