### PR TITLE
Update ignored_properties api

### DIFF
--- a/lib/couchbase-orm/utilities/ignored_properties.rb
+++ b/lib/couchbase-orm/utilities/ignored_properties.rb
@@ -1,9 +1,15 @@
 module CouchbaseOrm
     module IgnoredProperties
+        def ignored_properties=(properties)
+            @@ignored_properties = properties.map(&:to_s)
+        end
+
         def ignored_properties(*args)
+            if args.any?
+                CouchbaseOrm.logger.warn('Passing aruments to `.ignored_properties` is deprecated. PLease use `.ignored_properties=` intead.')
+                return send :ignored_properties=, args
+            end
             @@ignored_properties ||= []
-            return @@ignored_properties if args.empty?
-            @@ignored_properties += args.map(&:to_s)
         end
     end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -17,7 +17,7 @@ class TimestampTest < CouchbaseOrm::Base
 end
 
 class BaseTestWithIgnoredProperties < CouchbaseOrm::Base
-    ignored_properties :deprecated_property
+    self.ignored_properties += [:deprecated_property]
     attribute :name, :string
     attribute :job, :string
 end


### PR DESCRIPTION
To be similar to (usual) [ActiveRecord ignored columns](https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema/ClassMethods.html#method-i-ignored_columns)

-----

NB : there is a gotcha on using a class method ending with an equal sign : you have to make it explicit your are not assigning a local variable, but calling the setter mehod.

```ruby
## Good
class BaseTestWithIgnoredProperties < CouchbaseOrm::Base
    self.ignored_properties += [:some_deprecated_property]
end

## Good
class BaseTestWithIgnoredProperties < CouchbaseOrm::Base
    self.ignored_properties = [:some_deprecated_property]
end

## Also Good
class BaseTestWithIgnoredProperties < CouchbaseOrm::Base
    send :ignored_properties=, [:some_deprecated_property]
end

## KO
class BaseTestWithIgnoredProperties < CouchbaseOrm::Base
    ignored_properties += [:some_deprecated_property]
end


## Also KO
class BaseTestWithIgnoredProperties < CouchbaseOrm::Base
    ignored_properties = [:some_deprecated_property]
end

```