### PR TITLE
✨Handle strict_loading for model, record and relationship 

### DIFF
--- a/lib/couchbase-orm/associations.rb
+++ b/lib/couchbase-orm/associations.rb
@@ -32,6 +32,8 @@ module CouchbaseOrm
                     val = if options[:polymorphic]
                         ::CouchbaseOrm.try_load(self.send(ref))
                     else
+                        raise ActiveRecord::StrictLoadingViolationError, "#{self.class} is marked as strict_loading and #{assoc} cannot be lazily loaded." if strict_loading?
+
                         assoc.constantize.find(self.send(ref), quiet: true)
                     end
                     instance_variable_set(instance_var, val)

--- a/lib/couchbase-orm/associations.rb
+++ b/lib/couchbase-orm/associations.rb
@@ -83,6 +83,8 @@ module CouchbaseOrm
                     val = if options[:polymorphic]
                         ::CouchbaseOrm.try_load(ref_value) if ref_value
                     else
+                        raise ActiveRecord::StrictLoadingViolationError, "#{self.class} is marked as strict_loading and #{assoc} cannot be lazily loaded." if strict_loading?
+
                         assoc.constantize.find(ref_value) if ref_value
                     end
                     val = Array.wrap(val || [])

--- a/lib/couchbase-orm/base.rb
+++ b/lib/couchbase-orm/base.rb
@@ -213,6 +213,15 @@ module CouchbaseOrm
 
         define_model_callbacks :create, :destroy, :save, :update
 
+        def strict_loading
+            @strict_loading = true
+            self
+        end
+
+        def strict_loading?
+            !!@strict_loading
+        end
+
         class << self
             def connect(**options)
                 @bucket = BucketProxy.new(::MTLibcouchbase::Bucket.new(**options))
@@ -240,15 +249,6 @@ module CouchbaseOrm
 
             def uuid_generator=(generator)
                 @uuid_generator = generator
-            end
-            
-            def strict_loading
-                @strict_loading = true
-                self
-            end
-
-            def strict_loading?
-                !!@strict_loading
             end
 
             def find(*ids, quiet: false, with_strict_loading: false)

--- a/lib/couchbase-orm/base.rb
+++ b/lib/couchbase-orm/base.rb
@@ -241,6 +241,15 @@ module CouchbaseOrm
             def uuid_generator=(generator)
                 @uuid_generator = generator
             end
+            
+            def strict_loading
+                @strict_loading = true
+                self
+            end
+
+            def strict_loading?
+                !!@strict_loading
+            end
 
             def find(*ids, quiet: false)
                 CouchbaseOrm.logger.debug { "Base.find(l##{ids.length}) #{ids}" }

--- a/lib/couchbase-orm/base.rb
+++ b/lib/couchbase-orm/base.rb
@@ -251,7 +251,7 @@ module CouchbaseOrm
                 !!@strict_loading
             end
 
-            def find(*ids, quiet: false)
+            def find(*ids, quiet: false, with_strict_loading: false)
                 CouchbaseOrm.logger.debug { "Base.find(l##{ids.length}) #{ids}" }
 
                 ids = ids.flatten.select { |id| id.present? }
@@ -265,7 +265,9 @@ module CouchbaseOrm
                 records = records.zip(ids).map { |record, id|
                     next unless record
                     next if record.error
-                    self.new(record, id: id)
+                    new(record, id:).tap do |instance|
+                        instance.strict_loading! if with_strict_loading || strict_loading?
+                    end
                 }.compact
                 ids.length > 1 ? records : records[0]
             end

--- a/lib/couchbase-orm/base.rb
+++ b/lib/couchbase-orm/base.rb
@@ -265,7 +265,7 @@ module CouchbaseOrm
                 records = records.zip(ids).map { |record, id|
                     next unless record
                     next if record.error
-                    new(record, id:).tap do |instance|
+                    new(record, id: id).tap do |instance|
                         instance.strict_loading! if with_strict_loading || strict_loading?
                     end
                 }.compact

--- a/lib/couchbase-orm/base.rb
+++ b/lib/couchbase-orm/base.rb
@@ -213,15 +213,6 @@ module CouchbaseOrm
 
         define_model_callbacks :create, :destroy, :save, :update
 
-        def strict_loading
-            @strict_loading = true
-            self
-        end
-
-        def strict_loading?
-            !!@strict_loading
-        end
-
         class << self
             def connect(**options)
                 @bucket = BucketProxy.new(::MTLibcouchbase::Bucket.new(**options))
@@ -266,7 +257,9 @@ module CouchbaseOrm
                     next unless record
                     next if record.error
                     new(record, id: id).tap do |instance|
-                        instance.strict_loading! if with_strict_loading || strict_loading?
+                        if with_strict_loading
+                            instance.strict_loading!
+                        end
                     end
                 }.compact
                 ids.length > 1 ? records : records[0]

--- a/lib/couchbase-orm/relation.rb
+++ b/lib/couchbase-orm/relation.rb
@@ -60,13 +60,13 @@ module CouchbaseOrm
                 result = @model.cluster.query(self.limit(1).to_n1ql, Couchbase::Options::Query.new(scan_consistency: CouchbaseOrm::N1ql.config[:scan_consistency]))
                 return unless (first_id = result.rows.to_a.first)
 
-                @model.find(first_id).tap { |instance| instance.strict_loading! if @strict_loading || @model.strict_loading? }
+                @model.find(first_id, with_strict_loading: @strict_loading)
             end
 
             def last
                 result = @model.cluster.query(to_n1ql, Couchbase::Options::Query.new(scan_consistency: CouchbaseOrm::N1ql.config[:scan_consistency]))
                 last_id = result.rows.to_a.last
-                @model.find(last_id) if last_id
+                @model.find(last_id, with_strict_loading: @strict_loading) if last_id
             end
 
             def count

--- a/lib/couchbase-orm/relation.rb
+++ b/lib/couchbase-orm/relation.rb
@@ -3,14 +3,15 @@ module CouchbaseOrm
         extend ActiveSupport::Concern
 
         class CouchbaseOrm_Relation
-            def initialize(model:, where: where = nil, order: order = nil, limit: limit = nil, _not: _not = false)
-                CouchbaseOrm::logger.debug "CouchbaseOrm_Relation init: #{model} where:#{where.inspect} not:#{_not.inspect} order:#{order.inspect} limit: #{limit}"
+            def initialize(model:, where: where = nil, order: order = nil, limit: limit = nil, _not: _not = false, strict_loading: strict_loading = false)
+                CouchbaseOrm::logger.debug "CouchbaseOrm_Relation init: #{model} where:#{where.inspect} not:#{_not.inspect} order:#{order.inspect} limit: #{limit} strict_loading: #{strict_loading}"
                 @model = model
                 @limit = limit
                 @where = []
                 @order = {}
                 @order = merge_order(**order) if order
                 @where = merge_where(where, _not) if where
+                @strict_loading = strict_loading
                 CouchbaseOrm::logger.debug "- #{to_s}"
             end
 
@@ -52,8 +53,7 @@ module CouchbaseOrm
             end
 
             def strict_loading
-                @strict_loading = true
-                self
+                CouchbaseOrm_Relation.new(**initializer_arguments.merge(strict_loading: true))
             end
 
             def first
@@ -239,7 +239,7 @@ module CouchbaseOrm
 
             delegate :ids, :update_all, :delete_all, :count, :empty?, :filter, :reduce, :find_by, to: :all
 
-            delegate :where, :not, :order, :limit, :all, to: :relation
+            delegate :where, :not, :order, :limit, :all, :strict_loading, to: :relation
         end
     end
 end

--- a/lib/couchbase-orm/relation.rb
+++ b/lib/couchbase-orm/relation.rb
@@ -16,7 +16,7 @@ module CouchbaseOrm
             end
 
             def to_s
-                "CouchbaseOrm_Relation: #{@model} where:#{@where.inspect} order:#{@order.inspect} limit: #{@limit}"
+                "CouchbaseOrm_Relation: #{@model} where:#{@where.inspect} order:#{@order.inspect} limit: #{@limit} strict_loading: #{@strict_loading}"
             end
 
             def to_n1ql
@@ -54,6 +54,10 @@ module CouchbaseOrm
 
             def strict_loading
                 CouchbaseOrm_Relation.new(**initializer_arguments.merge(strict_loading: true))
+            end
+
+            def strict_loading?
+                !!@strict_loading
             end
 
             def first
@@ -95,7 +99,7 @@ module CouchbaseOrm
             def to_ary
                 ids = query.results
                 return [] if ids.empty?
-                Array(ids && @model.find(ids))
+                Array(ids && @model.find(ids, with_strict_loading: @strict_loading))
             end
 
             alias :to_a :to_ary
@@ -152,7 +156,7 @@ module CouchbaseOrm
             end
 
             def initializer_arguments
-                { model: @model, order: @order, where: @where, limit: @limit }
+                { model: @model, order: @order, where: @where, limit: @limit, strict_loading: @strict_loading }
             end
 
             def merge_order(*lorder, **horder)
@@ -239,7 +243,7 @@ module CouchbaseOrm
 
             delegate :ids, :update_all, :delete_all, :count, :empty?, :filter, :reduce, :find_by, to: :all
 
-            delegate :where, :not, :order, :limit, :all, :strict_loading, to: :relation
+            delegate :where, :not, :order, :limit, :all, :strict_loading, :strict_loading?, to: :relation
         end
     end
 end

--- a/lib/couchbase-orm/relation.rb
+++ b/lib/couchbase-orm/relation.rb
@@ -51,10 +51,16 @@ module CouchbaseOrm
                 query.to_a
             end
 
+            def strict_loading
+                @strict_loading = true
+                self
+            end
+
             def first
                 result = @model.cluster.query(self.limit(1).to_n1ql, Couchbase::Options::Query.new(scan_consistency: CouchbaseOrm::N1ql.config[:scan_consistency]))
-                first_id = result.rows.to_a.first
-                @model.find(first_id) if first_id
+                return unless (first_id = result.rows.to_a.first)
+
+                @model.find(first_id).tap { |instance| instance.strict_loading! if @strict_loading || @model.strict_loading? }
             end
 
             def last

--- a/spec/associations_spec.rb
+++ b/spec/associations_spec.rb
@@ -235,7 +235,9 @@ describe CouchbaseOrm::Associations do
             end
 
             it 'raises StrictLoadingViolationError on lazy loading habtm relation' do
-                expect {Parent.strict_loading.where(id: parent.id).first.children}.to raise_error(ActiveRecord::StrictLoadingViolationError) 
+                expect {Parent.strict_loading.where(id: parent.id).first.children}.to raise_error(ActiveRecord::StrictLoadingViolationError)
+                # NB any action called on model class breaks find return type (find return an enumerator instead of a record)
+                expect {Parent.strict_loading.find(parent.id).first.children}.to raise_error(ActiveRecord::StrictLoadingViolationError)
             end
         end
     end

--- a/spec/associations_spec.rb
+++ b/spec/associations_spec.rb
@@ -228,6 +228,11 @@ describe CouchbaseOrm::Associations do
                 expect_strict_loading_error_on_calling_parent(Child.strict_loading.where(id: child.id).to_a.first)
                 expect_strict_loading_error_on_calling_parent(Child.strict_loading.all.to_a.first)
             end
+
+            it 'does not raise StrictLoadingViolationError on lazy loading child relation without declaring it' do
+                expect_strict_loading_error_on_calling_parent(Child.strict_loading.where(id: child.id).first)
+                expect { Child.where(id: child.id).last.parent}.not_to raise_error
+            end
         end
     end
 

--- a/spec/associations_spec.rb
+++ b/spec/associations_spec.rb
@@ -5,6 +5,7 @@ require File.expand_path("../support", __FILE__)
 
 class Parent < CouchbaseOrm::Base
     attribute :name
+    has_and_belongs_to_many :children
 end
 
 class RandomOtherType < CouchbaseOrm::Base
@@ -231,6 +232,10 @@ describe CouchbaseOrm::Associations do
             it 'does not raise StrictLoadingViolationError on lazy loading child relation without declaring it' do
                 expect_strict_loading_error_on_calling_parent(Child.strict_loading.where(id: child.id).first)
                 expect { Child.where(id: child.id).last.parent}.not_to raise_error
+            end
+
+            it 'raises StrictLoadingViolationError on lazy loading habtm relation' do
+                expect {Parent.strict_loading.where(id: parent.id).first.children}.to raise_error(ActiveRecord::StrictLoadingViolationError) 
             end
         end
     end

--- a/spec/associations_spec.rb
+++ b/spec/associations_spec.rb
@@ -215,7 +215,6 @@ describe CouchbaseOrm::Associations do
         let(:child) {Child.create!(name: 'bob', parent_id: parent.id)}
         context 'instance strict loading' do
             it 'raises StrictLoadingViolationError on lazy loading child relation' do
-                
                 expect {child.parent.id}.not_to raise_error(ActiveRecord::StrictLoadingViolationError)
                 expect_strict_loading_error_on_calling_parent(Child.find(child.id).tap{|child| child.strict_loading!})
             end

--- a/spec/associations_spec.rb
+++ b/spec/associations_spec.rb
@@ -209,4 +209,13 @@ describe CouchbaseOrm::Associations do
             it_behaves_like "ActiveModel"
         end
     end
+
+    describe 'strict_loading' do
+        it 'raises StrictLoadingViolationError on lazy loading child relation' do
+            parent = Parent.create!(name: 'joe')
+            child  = Child.create!(name: 'bob', parent_id: parent.id)
+            child.strict_loading!
+            expect {child.parent.id}.to raise_error(ActiveRecord::StrictLoadingViolationError)
+        end
+    end
 end

--- a/spec/associations_spec.rb
+++ b/spec/associations_spec.rb
@@ -217,17 +217,21 @@ describe CouchbaseOrm::Associations do
             it 'raises StrictLoadingViolationError on lazy loading child relation' do
                 
                 expect {child.parent.id}.not_to raise_error(ActiveRecord::StrictLoadingViolationError)
-                expect {Child.find(child.id).tap{|child| child.strict_loading! }.parent.id}.to raise_error(ActiveRecord::StrictLoadingViolationError)
+                expect_strict_loading_error_on_calling_parent(Child.find(child.id).tap{|child| child.strict_loading!})
             end
         end
         context 'scope strict loading' do
             it 'raises StrictLoadingViolationError on lazy loading child relation' do
-                expect {Child.where(id: child.id).strict_loading.first.parent}.to raise_error(ActiveRecord::StrictLoadingViolationError)
-                expect {Child.strict_loading.where(id: child.id).first.parent}.to raise_error(ActiveRecord::StrictLoadingViolationError)
-                expect {Child.strict_loading.where(id: child.id).last.parent}.to raise_error(ActiveRecord::StrictLoadingViolationError)
-                expect {Child.strict_loading.where(id: child.id).to_a.first.parent}.to raise_error(ActiveRecord::StrictLoadingViolationError)
-                # ... cover all access methods (test should be refactored and split elsewhere)
+                expect_strict_loading_error_on_calling_parent(Child.where(id: child.id).strict_loading.first)
+                expect_strict_loading_error_on_calling_parent(Child.strict_loading.where(id: child.id).first)
+                expect_strict_loading_error_on_calling_parent(Child.strict_loading.where(id: child.id).last)
+                expect_strict_loading_error_on_calling_parent(Child.strict_loading.where(id: child.id).to_a.first)
+                expect_strict_loading_error_on_calling_parent(Child.strict_loading.all.to_a.first)
             end
         end
+    end
+
+    def expect_strict_loading_error_on_calling_parent(child_instance)
+      expect {child_instance.parent}.to raise_error(ActiveRecord::StrictLoadingViolationError)
     end
 end

--- a/spec/associations_spec.rb
+++ b/spec/associations_spec.rb
@@ -211,11 +211,23 @@ describe CouchbaseOrm::Associations do
     end
 
     describe 'strict_loading' do
-        it 'raises StrictLoadingViolationError on lazy loading child relation' do
-            parent = Parent.create!(name: 'joe')
-            child  = Child.create!(name: 'bob', parent_id: parent.id)
-            child.strict_loading!
-            expect {child.parent.id}.to raise_error(ActiveRecord::StrictLoadingViolationError)
+        let(:parent) {Parent.create!(name: 'joe')}
+        let(:child) {Child.create!(name: 'bob', parent_id: parent.id)}
+        context 'instance strict loading' do
+            it 'raises StrictLoadingViolationError on lazy loading child relation' do
+                
+                expect {child.parent.id}.not_to raise_error(ActiveRecord::StrictLoadingViolationError)
+                expect {Child.find(child.id).tap{|child| child.strict_loading! }.parent.id}.to raise_error(ActiveRecord::StrictLoadingViolationError)
+            end
+        end
+        context 'scope strict loading' do
+            it 'raises StrictLoadingViolationError on lazy loading child relation' do
+                expect {Child.where(id: child.id).strict_loading.first.parent}.to raise_error(ActiveRecord::StrictLoadingViolationError)
+                expect {Child.strict_loading.where(id: child.id).first.parent}.to raise_error(ActiveRecord::StrictLoadingViolationError)
+                expect {Child.strict_loading.where(id: child.id).last.parent}.to raise_error(ActiveRecord::StrictLoadingViolationError)
+                expect {Child.strict_loading.where(id: child.id).to_a.first.parent}.to raise_error(ActiveRecord::StrictLoadingViolationError)
+                # ... cover all access methods (test should be refactored and split elsewhere)
+            end
         end
     end
 end


### PR DESCRIPTION
To prevent N+1 request issue, enable strict_loading as done in ActiveRecord.

Exemple 

```ruby
class Parent < CouchbaseOrm::Base
    attribute :name
end

class Child < CouchbaseOrm::Base
    attribute :name
    belongs_to :parent, dependent: :destroy
end

parent = Parent.create!(name: 'joe')
child = Child.create!(name: 'bob', parent_id: parent.id)

n_plus_one_protected_child = Child.where(id: child.id).strict_loading.first
n_plus_one_protected_child.parent # raise ActiveRecord::StrictLoadingViolationError

### NB you can also call ActiveRecord::Core#strict_loading!
n_plus_one_protected_child = Child.where(id: child.id).first.strict_loading!
n_plus_one_protected_child.parent # raise ActiveRecord::StrictLoadingViolationError

```