### PR TITLE
fix docker build

### DIFF
--- a/lib/couchbase-orm/timestamps/updated.rb
+++ b/lib/couchbase-orm/timestamps/updated.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'pry'
 
 module CouchbaseOrm
   module Timestamps


### PR DESCRIPTION
Because of this line, the docker build production of `doctolib/doctolib` has failed ; leading to the revert of your PR. I want to do my best, to have this running the whole week-end on staging, but I don't have write access on this repository . . . So I have a fork, and will merge a PR that use my fork for now. I'll let you fix that on Monday.