### PR TITLE
🐛 Fix ignored properties

### DIFF
--- a/lib/couchbase-orm/utilities/ignored_properties.rb
+++ b/lib/couchbase-orm/utilities/ignored_properties.rb
@@ -1,7 +1,7 @@
 module CouchbaseOrm
     module IgnoredProperties
         def ignored_properties=(properties)
-            @@ignored_properties = properties.map(&:to_s)
+            @ignored_properties = properties.map(&:to_s)
         end
 
         def ignored_properties(*args)
@@ -9,7 +9,7 @@ module CouchbaseOrm
                 CouchbaseOrm.logger.warn('Passing aruments to `.ignored_properties` is deprecated. PLease use `.ignored_properties=` intead.')
                 return send :ignored_properties=, args
             end
-            @@ignored_properties ||= []
+            @ignored_properties ||= []
         end
     end
 end

--- a/spec/utilities/ignored_properties_spec.rb
+++ b/spec/utilities/ignored_properties_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe CouchbaseOrm::IgnoredProperties do
   describe '#ignored_properties=' do
     it 'does not mixup ignored properties between classes' do
       DummyClass.ignored_properties = [:property1, :property2]
-      expect(DummyClass.instance_variable_get(:@ignored_properties)).to eq(['property1', 'property2'])
-      expect(DummyClass2.instance_variable_get(:@ignored_properties)).to be_nil
+      expect(DummyClass.ignored_properties).to eq(['property1', 'property2'])
+      expect(DummyClass2.ignored_properties).to be_empty
     end
   end
 end

--- a/spec/utilities/ignored_properties_spec.rb
+++ b/spec/utilities/ignored_properties_spec.rb
@@ -1,0 +1,20 @@
+require 'couchbase-orm/utilities/ignored_properties'
+
+class DummyClass
+  extend CouchbaseOrm::IgnoredProperties
+end
+
+class DummyClass2
+  extend CouchbaseOrm::IgnoredProperties
+end
+
+RSpec.describe CouchbaseOrm::IgnoredProperties do
+
+  describe '#ignored_properties=' do
+    it 'does not mixup ignored properties between classes' do
+      DummyClass.ignored_properties = [:property1, :property2]
+      expect(DummyClass.instance_variable_get(:@ignored_properties)).to eq(['property1', 'property2'])
+      expect(DummyClass2.instance_variable_get(:@ignored_properties)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Ignored properties were only set once for the first model, then had the same value for any other models.