### PR TITLE
[BIC-1903] Add configuration for is null / is not valued

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,13 @@ When using a compound key, the usage is the same, you just give the full key :
    # gives all comments that have been seen more than 10 times but less than 20
 ```
 
+```ruby
+    class Comment < CouchbaseOrm::Base
+      self.ignored_properties = [:old_name] # ignore old_name property in the model
+      self.properties_always_exists_in_document = true # use is null for nil value instead of not valued for performance purpose, only possible if all property always exists in document
+    end
+```      
+
 Check this couchbase help page to learn more on what's possible with compound keys : <https://developer.couchbase.com/documentation/server/3.x/admin/Views/views-translateSQL.html>
 
 Ex : Compound keys allows to decide the order of the results, and you can reverse it by passing `descending: true`

--- a/README.md
+++ b/README.md
@@ -182,17 +182,20 @@ When using a compound key, the usage is the same, you just give the full key :
    
    # gives all comments that have been seen more than 10 times but less than 20
 ```
+Check this couchbase help page to learn more on what's possible with compound keys : <https://developer.couchbase.com/documentation/server/3.x/admin/Views/views-translateSQL.html>
+
+Ex : Compound keys allows to decide the order of the results, and you can reverse it by passing `descending: true`
 
 ```ruby
     class Comment < CouchbaseOrm::Base19
       self.ignored_properties = [:old_name] # ignore old_name property in the model
-      self.properties_always_exists_in_document = true # use is null for nil value instead of not valued for performance purpose, only possible if all property always exists in document
+      self.properties_always_exists_in_document = true # use is null for nil value instead of not valued for performance purpose, only possible if all properties always exists in document
     end
 ```      
+You can specify `properties_always_exists_in_document` to true if all properties always exists in document, this will allow to use `is null` instead of `not valued` for nil value, this will improve performance. 
 
-Check this couchbase help page to learn more on what's possible with compound keys : <https://developer.couchbase.com/documentation/server/3.x/admin/Views/views-translateSQL.html>
+WARNING: If a document exists without a property, the query will failed! So you must be sure that all documents have all properties.
 
-Ex : Compound keys allows to decide the order of the results, and you can reverse it by passing `descending: true`
 
 ## N1ql
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ When using a compound key, the usage is the same, you just give the full key :
 ```
 
 ```ruby
-    class Comment < CouchbaseOrm::Base
+    class Comment < CouchbaseOrm::Base19
       self.ignored_properties = [:old_name] # ignore old_name property in the model
       self.properties_always_exists_in_document = true # use is null for nil value instead of not valued for performance purpose, only possible if all property always exists in document
     end

--- a/lib/couchbase-orm/base.rb
+++ b/lib/couchbase-orm/base.rb
@@ -26,6 +26,8 @@ require 'couchbase-orm/json_transcoder'
 require 'couchbase-orm/timestamps'
 require 'couchbase-orm/active_record_compat'
 require 'couchbase-orm/strict_loading'
+require 'couchbase-orm/utilities/properties_always_exists_in_document'
+
 
 
 module CouchbaseOrm
@@ -134,6 +136,7 @@ module CouchbaseOrm
         extend HasMany
         extend Index
         extend IgnoredProperties
+        extend PropertiesAlwaysExistsInDocument
 
 
         class << self

--- a/lib/couchbase-orm/utilities/ignored_properties.rb
+++ b/lib/couchbase-orm/utilities/ignored_properties.rb
@@ -6,7 +6,7 @@ module CouchbaseOrm
 
         def ignored_properties(*args)
             if args.any?
-                CouchbaseOrm.logger.warn('Passing aruments to `.ignored_properties` is deprecated. PLease use `.ignored_properties=` intead.')
+                CouchbaseOrm.logger.warn('Passing aruments to `.ignored_properties` is deprecated. PLease use `.ignored_properties=` instead.')
                 return send :ignored_properties=, args
             end
             @ignored_properties ||= []

--- a/lib/couchbase-orm/utilities/properties_always_exists_in_document.rb
+++ b/lib/couchbase-orm/utilities/properties_always_exists_in_document.rb
@@ -1,0 +1,14 @@
+module CouchbaseOrm
+    module PropertiesAlwaysExistsInDocument
+        def properties_always_exists_in_document=(value)
+            unless [true, false].include? value
+                raise ArgumentError.new("properties_always_exists_in_document must be a boolean")
+            end
+            @properties_always_exists_in_document = value
+        end
+
+        def properties_always_exists_in_document
+            @properties_always_exists_in_document ||= false
+        end
+    end
+end

--- a/lib/couchbase-orm/utilities/properties_always_exists_in_document.rb
+++ b/lib/couchbase-orm/utilities/properties_always_exists_in_document.rb
@@ -1,5 +1,7 @@
 module CouchbaseOrm
     module PropertiesAlwaysExistsInDocument
+
+        DEFAULT_VALUE = false
         def properties_always_exists_in_document=(value)
             unless [true, false].include? value
                 raise ArgumentError.new("properties_always_exists_in_document must be a boolean")
@@ -8,7 +10,7 @@ module CouchbaseOrm
         end
 
         def properties_always_exists_in_document
-            @properties_always_exists_in_document ||= false
+            @properties_always_exists_in_document ||= DEFAULT_VALUE
         end
     end
 end

--- a/lib/couchbase-orm/utilities/query_helper.rb
+++ b/lib/couchbase-orm/utilities/query_helper.rb
@@ -5,9 +5,12 @@ module CouchbaseOrm
         module ClassMethods
 
             def build_match(key, value)
+                use_is_null = self.properties_always_exists_in_document
                 key = "meta().id" if key.to_s == "id"
                 case
-                when value.nil?
+                when value.nil? && use_is_null
+                    "#{key} IS NULL"
+                when value.nil? && !use_is_null
                     "#{key} IS NOT VALUED"
                 when value.is_a?(Hash)
                     build_match_hash(key, value)
@@ -86,9 +89,12 @@ module CouchbaseOrm
 
 
             def build_not_match(key, value)
+                use_is_null = self.properties_always_exists_in_document
                 key = "meta().id" if key.to_s == "id"
                 case
-                when value.nil?
+                when value.nil? && use_is_null
+                    "#{key} IS NULL"
+                when value.nil? && !use_is_null
                     "#{key} IS VALUED"
                 when value.is_a?(Array) && value.include?(nil)
                     "(#{build_not_match(key, nil)} AND #{build_not_match(key, value.compact)})"

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -330,14 +330,14 @@ describe CouchbaseOrm::Base do
     end
 
     describe '.properties_always_exists_in_document' do
-        fit 'Uses NOT VALUED when properties_always_exists_in_document = false' do
+        it 'Uses NOT VALUED when properties_always_exists_in_document = false' do
             where_clause = BaseTest.where(name: nil)
-            expect(where_clause.to_n1ql).to eq("select raw meta().id from `billeo-cb-bucket` where type = 'base_test' AND name IS NOT VALUED order by meta().id ")
+            expect(where_clause.to_n1ql).to include("AND name IS NOT VALUED")
         end
 
-        it 'Uses NOT VALUED when properties_always_exists_in_document = true' do
+        it 'Uses IS NULL when properties_always_exists_in_document = true' do
             where_clause = BaseTestWithPropertiesAlwaysExistsInDocument.where(name: nil)
-            expect(where_clause.to_n1ql).to eq("select raw meta().id from `billeo-cb-bucket` where type = 'base_test_with_properties_always_exists_in_document' AND name IS NULL order by meta().id ")
+            expect(where_clause.to_n1ql).to include("AND name IS NULL")
         end
     end
 end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -22,6 +22,11 @@ class BaseTestWithIgnoredProperties < CouchbaseOrm::Base
     attribute :job, :string
 end
 
+class BaseTestWithPropertiesAlwaysExistsInDocument < CouchbaseOrm::Base
+    self.properties_always_exists_in_document = true
+    attribute :name, :string
+end
+
 class DocInvalidOnUpdate < CouchbaseOrm::Base
     attribute :title
     validate :foo, on: :update
@@ -286,8 +291,6 @@ describe CouchbaseOrm::Base do
     end
 
     describe '.ignored_properties' do
-
-
         it 'returns an array of ignored properties' do
             expect(BaseTestWithIgnoredProperties.ignored_properties).to eq(['deprecated_property'])
         end
@@ -323,6 +326,18 @@ describe CouchbaseOrm::Base do
             it 'does not raise for reload' do
                 expect{ loaded_model.reload }.not_to raise_error
             end
+        end
+    end
+
+    describe '.properties_always_exists_in_document' do
+        fit 'Uses NOT VALUED when properties_always_exists_in_document = false' do
+            where_clause = BaseTest.where(name: nil)
+            expect(where_clause.to_n1ql).to eq("select raw meta().id from `billeo-cb-bucket` where type = 'base_test' AND name IS NOT VALUED order by meta().id ")
+        end
+
+        it 'Uses NOT VALUED when properties_always_exists_in_document = true' do
+            where_clause = BaseTestWithPropertiesAlwaysExistsInDocument.where(name: nil)
+            expect(where_clause.to_n1ql).to eq("select raw meta().id from `billeo-cb-bucket` where type = 'base_test_with_properties_always_exists_in_document' AND name IS NULL order by meta().id ")
         end
     end
 end

--- a/spec/utilities/properties_always_exists_in_document_spec.rb
+++ b/spec/utilities/properties_always_exists_in_document_spec.rb
@@ -1,0 +1,24 @@
+require 'couchbase-orm/utilities/properties_always_exists_in_document'
+
+class DummyClass
+  extend CouchbaseOrm::PropertiesAlwaysExistsInDocument
+end
+
+class DummyClass2
+  extend CouchbaseOrm::PropertiesAlwaysExistsInDocument
+end
+
+RSpec.describe CouchbaseOrm::PropertiesAlwaysExistsInDocument do
+
+  describe '#properties_always_exists_in_document=' do
+    it 'Checks properties_always_exists_in_document value when initialize or not' do
+      DummyClass.properties_always_exists_in_document = true
+      expect(DummyClass.properties_always_exists_in_document).to be(true)
+      expect(DummyClass2.properties_always_exists_in_document).to be(false)
+    end
+
+    it 'raises error when a non boolean value is passed' do
+      expect { DummyClass.properties_always_exists_in_document = 'toto' }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
Add a property `properties_always_exists_in_document` on model to be able to use `IS NULL` instead of `IS NOT VALUED` when `true`