### PR TITLE
[BIC-1903] Fix use of properties_always_exists_in_document for not match case

### DIFF
--- a/lib/couchbase-orm/utilities/query_helper.rb
+++ b/lib/couchbase-orm/utilities/query_helper.rb
@@ -93,7 +93,7 @@ module CouchbaseOrm
                 key = "meta().id" if key.to_s == "id"
                 case
                 when value.nil? && use_is_null
-                    "#{key} IS NULL"
+                    "#{key} IS NOT NULL"
                 when value.nil? && !use_is_null
                     "#{key} IS VALUED"
                 when value.is_a?(Array) && value.include?(nil)

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -335,9 +335,19 @@ describe CouchbaseOrm::Base do
             expect(where_clause.to_n1ql).to include("AND name IS NOT VALUED")
         end
 
+        it 'Uses VALUED when properties_always_exists_in_document = false' do
+            where_clause = BaseTest.where.not(name: nil)
+            expect(where_clause.to_n1ql).to include("AND name IS VALUED")
+        end
+
         it 'Uses IS NULL when properties_always_exists_in_document = true' do
             where_clause = BaseTestWithPropertiesAlwaysExistsInDocument.where(name: nil)
             expect(where_clause.to_n1ql).to include("AND name IS NULL")
+        end
+
+        it 'Uses IS NOT NULL when properties_always_exists_in_document = true' do
+            where_clause = BaseTestWithPropertiesAlwaysExistsInDocument.where.not(name: nil)
+            expect(where_clause.to_n1ql).to include("AND name IS NOT NULL")
         end
     end
 end


### PR DESCRIPTION
I tried to activate the property in the [monolith](https://github.com/doctolib/doctolib/pull/154577) but I'm wrongly managed the not mach case 😢

Fix => In `build_not_match` I need to request for `IS NOT NULL` #34 