### PR TITLE
⬆️ Support couchbase > 3.4.2

### DIFF
--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'activemodel', ENV['ACTIVE_MODEL_VERSION'] || '>= 5.2'
 
-  gem.add_runtime_dependency     'couchbase',    '~> 3.4.2'
+  gem.add_runtime_dependency     'couchbase',    '>= 3.4.2'
   gem.add_runtime_dependency     'radix',        '~> 2.2' # converting numbers to and from any base
   gem.add_runtime_dependency     'json-schema',  '>= 3' # validating JSON against a schema
 


### PR DESCRIPTION
Since couchbase 3.5.0, pre-built binaries are available for most used architectures. 