### PR TITLE
[APE] Fix DATETIME format using serialize of DateTime

### DIFF
--- a/lib/couchbase-orm/utilities/query_helper.rb
+++ b/lib/couchbase-orm/utilities/query_helper.rb
@@ -132,10 +132,10 @@ module CouchbaseOrm
             end
 
             def quote(value)
-                if [String, Date, Time].any? { |clazz| value.is_a?(clazz) }
+                if [String, Date].any? { |clazz| value.is_a?(clazz) }
                     "'#{N1ql.sanitize(value)}'"
-                elsif value.is_a? DateTime
-                    formatedDate = DateTime.serialize(value)
+                elsif [DateTime, Time].any? { |clazz| value.is_a?(clazz) }
+                    formatedDate = value&.iso8601(@precision)
                     "'#{N1ql.sanitize(formatedDate)}'"
                 elsif value.is_a? Array
                     "[#{value.map{|v|quote(v)}.join(', ')}]"

--- a/lib/couchbase-orm/utilities/query_helper.rb
+++ b/lib/couchbase-orm/utilities/query_helper.rb
@@ -132,8 +132,11 @@ module CouchbaseOrm
             end
 
             def quote(value)
-                if [String, DateTime, Date, Time].any? { |clazz| value.is_a?(clazz) }
+                if [String, Date, Time].any? { |clazz| value.is_a?(clazz) }
                     "'#{N1ql.sanitize(value)}'"
+                elsif value.is_a? DateTime
+                    formatedDate = DateTime.serialize(value)
+                    "'#{N1ql.sanitize(formatedDate)}'"
                 elsif value.is_a? Array
                     "[#{value.map{|v|quote(v)}.join(', ')}]"
                 elsif value.nil?

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -366,7 +366,7 @@ describe CouchbaseOrm::Base do
         end
 
         it 'manages the datetime range correctly' do
-            result = BaseTestWithTimeframe.where(start_date: DateTime.new(2020, 1, 1,11, 0,0)..DateTime.new(2020, 1, 31)).pluck(:name)
+            result = BaseTestWithTimeframe.where(start_date: DateTime.new(2020, 1, 1, 11, 0,0)..DateTime.new(2020, 1, 31)).pluck(:name)
             expect(result).to eq(%w[midjanuary])
         end
 
@@ -377,7 +377,7 @@ describe CouchbaseOrm::Base do
 
         it 'manages the time range correctly' do
             result = BaseTestWithTimeframe.where(start_date: Time.new(2020, 1, 1, 14, 35, 0)..Time.new(2020, 1, 31, 16, 35, 0)).pluck(:name)
-            expect(result).to eq(%w[january midjanuary])
+            expect(result).to eq(%w[midjanuary])
         end
 
         it 'manages the integer range correctly' do

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -360,14 +360,14 @@ describe CouchbaseOrm::Base do
     describe 'With a range in the where clause' do
         before do
             BaseTestWithTimeframe.delete_all
-            BaseTestWithTimeframe.create!(name: 'january', start_date: DateTime.new(2020, 1, 1), age: 10)
-            BaseTestWithTimeframe.create!(name: 'midjanuary', start_date: DateTime.new(2020, 1, 15), age: 15)
-            BaseTestWithTimeframe.create!(name: 'february', start_date: DateTime.new(2020, 2, 1), age: 20)
+            BaseTestWithTimeframe.create!(name: 'january', start_date: DateTime.new(2020, 1, 1, 10, 0, 0), age: 10)
+            BaseTestWithTimeframe.create!(name: 'midjanuary', start_date: DateTime.new(2020, 1, 15,11, 0, 0), age: 15)
+            BaseTestWithTimeframe.create!(name: 'february', start_date: DateTime.new(2020, 2, 1,15, 0, 0), age: 20)
         end
 
         it 'manages the datetime range correctly' do
-            result = BaseTestWithTimeframe.where(start_date: DateTime.new(2020, 1, 1)..DateTime.new(2020, 1, 31)).pluck(:name)
-            expect(result).to eq(%w[january midjanuary])
+            result = BaseTestWithTimeframe.where(start_date: DateTime.new(2020, 1, 1,11, 0,0)..DateTime.new(2020, 1, 31)).pluck(:name)
+            expect(result).to eq(%w[midjanuary])
         end
 
         it 'manages the date range correctly' do


### PR DESCRIPTION
The format was not well manage for the `DateTime` and `Time`.

We now apply the `iso8601` format to `DateTime` and `Time` and the caller is not obliged to format the dates when using CB ORM like that:

```
 Meet.where(started_at: @period_start.iso8601..@period_end.iso8601)
```


## Why ?

When building a select query containing a data param with time, example   

```ruby
Meet.where(started_at: @period_start..@period_end)
```

When, the `@period_end` is an `ActiveSupport::TimeWithZone`, on interpollation time, it gives `2024-01-31 23:59:59 +0100`

Then, the query above yields a n1ql wih the following clause :

`AND started_at >= '2024-01-01 00:00:00 +0100' AND started_at <= '2024-01-31 23:59:59 +0100' `

Note the date formats in that clause.
However, the started_at  MIGHT/MUST/SHOULD be formated differently, like this : `2024-01-31T13:00:00Z`

Because of this format miss-match, all documents having a started_at at the last date of the period are missed by the query.

It seems that CB compares dates as strings, When I run this query:
select  '2024-01-31T13:00:00Z' < '2024-01-31 23:59:59 +0100'
I get "$1": false Because the char T is grater than the char space